### PR TITLE
Separate benchmarking from solver

### DIFF
--- a/examples/julia_matrix_equation/README.md
+++ b/examples/julia_matrix_equation/README.md
@@ -1,0 +1,29 @@
+# Julia Quadratic Matrix Equation Example
+
+This example shows how OpenEvolve can evolve a Julia implementation for solving the quadratic matrix equation
+
+\[ A \* X^2 + B \* X + C = 0 \]
+
+The solver contained in `initial_program.jl` implements a simple **quadratic iteration** method.  All benchmarking code has been moved to a separate `benchmark.jl` script so that only the function inside the EVOLVE-BLOCK is evolved.  Random matrices are generated with `Random.seed!`, and runtime/allocation metrics are gathered using a single `@benchmark` call from **BenchmarkTools.jl**.
+
+## Files
+- `initial_program.jl` – starting Julia implementation containing the EVOLVE-BLOCK.
+- `benchmark.jl` – runs the solver, measures performance, and prints JSON metrics.
+- `evaluator.py` – Python evaluator that calls `benchmark.jl`.
+- `config.yaml` – minimal configuration tuned for this example.
+- `requirements.txt` – Python dependencies (none). Julia must be installed separately.
+
+The benchmark suite expects a function named `solve_quadratic_matrix_equation(A, B, C; initial_guess=zeros(size(A)), tol=1e-14, max_iter=50000)` in `initial_program.jl`. If you prefer another name, provide a thin wrapper with this signature so `benchmark.jl` can call it.
+
+## Usage
+```bash
+cd examples/julia_matrix_equation
+python ../../openevolve-run.py initial_program.jl evaluator.py --config config.yaml --iterations 50
+```
+
+Ensure that `julia` is available on your PATH (version 1.9 or higher).  Install the benchmarking dependency once with:
+
+```julia
+using Pkg; Pkg.add("BenchmarkTools")
+```
+

--- a/examples/julia_matrix_equation/benchmark.jl
+++ b/examples/julia_matrix_equation/benchmark.jl
@@ -1,0 +1,34 @@
+using LinearAlgebra
+using Random
+using JSON
+using BenchmarkTools
+
+include(ARGS[1])
+
+function generate_problem(n::Int = 2, seed::Int = 0)
+    Random.seed!(seed)
+    A = 0.1 .* randn(n, n)
+    B = I + 0.05 .* randn(n, n)
+    C = -0.5 .* I + 0.05 .* randn(n, n)
+    return A, B, C
+end
+
+function run_benchmark()
+    A, B, C = generate_problem()
+    trial = @benchmark solve_quadratic_matrix_equation($A, $B, $C) samples=1 evals=1
+    exec_time = trial.time / 1e9
+    alloc = trial.memory
+    X, iters = solve_quadratic_matrix_equation(A, B, C)
+    residual = norm(A * X * X + B * X + C)
+
+    return Dict(
+        "iterations" => iters,
+        "time" => exec_time,
+        "allocations" => alloc,
+        "residual" => residual,
+    )
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    println(JSON.json(run_benchmark()))
+end

--- a/examples/julia_matrix_equation/benchmark.jl
+++ b/examples/julia_matrix_equation/benchmark.jl
@@ -21,7 +21,7 @@ function run_benchmark()
     alloc = trial.allocs
     mem = trial.memory
     X, iters = solve_quadratic_matrix_equation(A, B, C)
-    residual = norm(A * X * X + B * X + C)
+    residual = log10(norm(A * X * X + B * X + C))
 
     return Dict(
         "memory" => mem,

--- a/examples/julia_matrix_equation/benchmark.jl
+++ b/examples/julia_matrix_equation/benchmark.jl
@@ -5,7 +5,7 @@ using BenchmarkTools
 
 include(ARGS[1])
 
-function generate_problem(n::Int = 2, seed::Int = 0)
+function generate_problem(n::Int = 20, seed::Int = 0)
     Random.seed!(seed)
     A = 0.1 .* randn(n, n)
     B = I + 0.05 .* randn(n, n)
@@ -15,14 +15,16 @@ end
 
 function run_benchmark()
     A, B, C = generate_problem()
-    trial = @benchmark solve_quadratic_matrix_equation($A, $B, $C) samples=1 evals=1
-    exec_time = trial.time / 1e9
-    alloc = trial.memory
+    
+    trial = @benchmark solve_quadratic_matrix_equation($A, $B, $C)# samples=1 evals=1
+    exec_time = median(trial.times)
+    alloc = trial.allocs
+    mem = trial.memory
     X, iters = solve_quadratic_matrix_equation(A, B, C)
     residual = norm(A * X * X + B * X + C)
 
     return Dict(
-        "iterations" => iters,
+        "memory" => mem,
         "time" => exec_time,
         "allocations" => alloc,
         "residual" => residual,

--- a/examples/julia_matrix_equation/config.yaml
+++ b/examples/julia_matrix_equation/config.yaml
@@ -1,0 +1,35 @@
+# Configuration for Julia quadratic matrix equation example
+max_iterations: 50
+checkpoint_interval: 10
+log_level: "INFO"
+
+llm:
+  primary_model: "gemini-2.0-flash"
+  primary_model_weight: 0.6
+  secondary_model: "gemini-2.5-flash-preview-05-20"
+  secondary_model_weight: 0.4
+  api_base: "https://generativelanguage.googleapis.com/v1beta/openai/"
+  api_key: YOUR_API_KEY
+  temperature: 0.7
+  max_tokens: 1024
+
+prompt:
+  system_message: |
+    You are an expert Julia programmer specializing in numerical linear algebra.
+    Focus on optimizing the solve_quadratic_matrix_equation function inside the
+    EVOLVE-BLOCK to reduce execution time and memory allocations while achieving
+    a residual below 1e-14.
+  num_top_programs: 3
+
+database:
+  population_size: 20
+  num_islands: 2
+  feature_dimensions:
+    - "combined_score"
+
+evaluator:
+  timeout: 30
+  cascade_evaluation: false
+  parallel_evaluations: 1
+
+diff_based_evolution: true

--- a/examples/julia_matrix_equation/config.yaml
+++ b/examples/julia_matrix_equation/config.yaml
@@ -1,17 +1,34 @@
 # Configuration for Julia quadratic matrix equation example
-max_iterations: 50
+max_iterations: 200
 checkpoint_interval: 10
 log_level: "INFO"
 
 llm:
-  primary_model: "gemini-2.0-flash"
+  # primary_model: "gemini-2.0-flash"
+  # primary_model_weight: 0.6
+  # secondary_model: "gemini-2.0-flash-lite"
+  # secondary_model_weight: 0.4
+  # api_base: "https://generativelanguage.googleapis.com/v1beta/openai/"
+  # api_key: AIzaSyBnaapUMa4OJOXAvTmyV7Q87Aptqb0TswE
+  primary_model: "qwen2.5-coder:3b" #
+  # primary_model: "deepseek-r1:1.5b"
   primary_model_weight: 0.6
-  secondary_model: "gemini-2.5-flash-preview-05-20"
+  # secondary_model: "mathstral" 
+  # secondary_model: "codellama"
+  secondary_model: "codegemma:2b"
   secondary_model_weight: 0.4
-  api_base: "https://generativelanguage.googleapis.com/v1beta/openai/"
-  api_key: YOUR_API_KEY
-  temperature: 0.7
-  max_tokens: 1024
+  api_base: "http://localhost:11434/v1" # Together AI endpoint
+  api_key: ollama
+  # primary_model: "deepseek-ai/DeepSeek-R1-Distill-Llama-70B-free"
+  # primary_model_weight: 0.6
+  # secondary_model: "deepseek-ai/DeepSeek-R1-0528"
+  # secondary_model_weight: 0.4
+  # api_base: "https://api.together.xyz/v1" # Together AI endpoint
+  # api_key: 0761d4e838e60a367b373064bce641a112532f835d3144034e47d579e0180119
+  # temperature: 0.6
+  # top_p: 0.95
+  max_tokens: 28000
+  timeout: 900
 
 prompt:
   system_message: |
@@ -20,16 +37,32 @@ prompt:
     EVOLVE-BLOCK to reduce execution time and memory allocations while achieving
     a residual below 1e-14.
   num_top_programs: 3
+  num_diverse_programs: 2
+
+  # Template stochasticity
+  use_template_stochasticity: true # Use random variations in templates for diversity
+  template_variations:
+    # Different phrasings for parts of the template
+    improvement_suggestion:
+    - "Consider implementing buffers"
+    - "Use other libraries, like SpeedMapping, LinearSolve and the like to try and speed up the algorithm"
+    - "Consider other algorithm like e.g. doubling"
+    - "Think of other ways in getting reliable and fast solutions"
 
 database:
   population_size: 20
-  num_islands: 2
+  num_islands: 3
+  elite_selection_ratio: 0.3
+  exploitation_ratio: 0.65
+  exploration_ratio: 0.35
   feature_dimensions:
-    - "combined_score"
+  - "combined_score"
 
 evaluator:
   timeout: 30
   cascade_evaluation: false
   parallel_evaluations: 1
 
+# Evolution settings
 diff_based_evolution: true
+allow_full_rewrites: true

--- a/examples/julia_matrix_equation/config.yaml
+++ b/examples/julia_matrix_equation/config.yaml
@@ -4,27 +4,29 @@ checkpoint_interval: 10
 log_level: "INFO"
 
 llm:
-  # primary_model: "gemini-2.0-flash"
-  # primary_model_weight: 0.6
-  # secondary_model: "gemini-2.0-flash-lite"
-  # secondary_model_weight: 0.4
-  # api_base: "https://generativelanguage.googleapis.com/v1beta/openai/"
-  # api_key: AIzaSyBnaapUMa4OJOXAvTmyV7Q87Aptqb0TswE
-  primary_model: "qwen2.5-coder:3b" #
-  # primary_model: "deepseek-r1:1.5b"
+  primary_model: "gemini-2.5-flash-lite-preview-06-17"
   primary_model_weight: 0.6
-  # secondary_model: "mathstral" 
-  # secondary_model: "codellama"
-  secondary_model: "codegemma:2b"
+  secondary_model: "gemini-2.0-flash-lite"
   secondary_model_weight: 0.4
-  api_base: "http://localhost:11434/v1" # Together AI endpoint
-  api_key: ollama
+  api_base: "https://generativelanguage.googleapis.com/v1beta/openai/"
+  api_key:
+
+  # primary_model: "qwen2.5-coder:3b" #
+  # # primary_model: "deepseek-r1:1.5b"
+  # primary_model_weight: 0.6
+  # # secondary_model: "mathstral" 
+  # # secondary_model: "codellama"
+  # secondary_model: "codegemma:2b"
+  # secondary_model_weight: 0.4
+  # api_base: "http://localhost:11434/v1" # Together AI endpoint
+  # api_key: ollama
+
   # primary_model: "deepseek-ai/DeepSeek-R1-Distill-Llama-70B-free"
   # primary_model_weight: 0.6
   # secondary_model: "deepseek-ai/DeepSeek-R1-0528"
   # secondary_model_weight: 0.4
   # api_base: "https://api.together.xyz/v1" # Together AI endpoint
-  # api_key: 0761d4e838e60a367b373064bce641a112532f835d3144034e47d579e0180119
+  # api_key: 
   # temperature: 0.6
   # top_p: 0.95
   max_tokens: 28000

--- a/examples/julia_matrix_equation/evaluator.py
+++ b/examples/julia_matrix_equation/evaluator.py
@@ -23,7 +23,9 @@ def evaluate(program_path: str):
             time_val = metrics.get("time", 1.0)
             alloc = metrics.get("allocations", 0.0)
             memory = metrics.get("memory", 0.0)
-            metrics["combined_score"] = 1e6 / (time_val + alloc * 100 + memory)
+            min_obj = time_val + alloc * 100 + memory
+            min_obj = min_obj if min_obj > 0 else 1e12
+            metrics["combined_score"] = 1e6 / min_obj
 
         return metrics
     except Exception as e:

--- a/examples/julia_matrix_equation/evaluator.py
+++ b/examples/julia_matrix_equation/evaluator.py
@@ -1,0 +1,29 @@
+"""Evaluator for Julia quadratic matrix equation example"""
+
+import json
+import subprocess
+
+
+def evaluate(program_path: str):
+    """Run the Julia solver and compute metrics"""
+    try:
+        result = subprocess.run([
+            "julia",
+            "benchmark.jl",
+            program_path,
+        ], capture_output=True, text=True, timeout=30)
+        if result.returncode != 0:
+            return {"combined_score": 0.0, "error": result.stderr}
+
+        metrics = json.loads(result.stdout.strip().splitlines()[-1])
+
+        if metrics.get("residual", 1.0) > 1e-14:
+            metrics["combined_score"] = 0.0
+        else:
+            time_val = metrics.get("time", 1.0)
+            alloc = metrics.get("allocations", 0.0)
+            metrics["combined_score"] = 1.0 / (time_val + alloc / 1e6 + 1e-12)
+
+        return metrics
+    except Exception as e:
+        return {"combined_score": 0.0, "error": str(e)}

--- a/examples/julia_matrix_equation/evaluator.py
+++ b/examples/julia_matrix_equation/evaluator.py
@@ -22,7 +22,8 @@ def evaluate(program_path: str):
         else:
             time_val = metrics.get("time", 1.0)
             alloc = metrics.get("allocations", 0.0)
-            metrics["combined_score"] = 1.0 / (time_val + alloc / 1e6 + 1e-12)
+            memory = metrics.get("memory", 0.0)
+            metrics["combined_score"] = 1e6 / (time_val + alloc * 100 + memory)
 
         return metrics
     except Exception as e:

--- a/examples/julia_matrix_equation/initial_program.jl
+++ b/examples/julia_matrix_equation/initial_program.jl
@@ -1,5 +1,3 @@
-using LinearAlgebra
-
 # EVOLVE-BLOCK-START
 function solve_quadratic_matrix_equation(
     A::AbstractMatrix{T},

--- a/examples/julia_matrix_equation/initial_program.jl
+++ b/examples/julia_matrix_equation/initial_program.jl
@@ -1,0 +1,39 @@
+using LinearAlgebra
+
+# EVOLVE-BLOCK-START
+function solve_quadratic_matrix_equation(
+    A::AbstractMatrix{T},
+    B::AbstractMatrix{T},
+    C::AbstractMatrix{T};
+    initial_guess=zeros(size(A)),
+    tol=1e-14,
+    max_iter=50000,
+) where {T<:Real}
+    F = lu(B)
+    A_bar = F \ A
+    C_bar = F \ C
+
+    X = copy(initial_guess)
+    X_new = similar(X)
+    X2 = similar(X)
+    diff = similar(X)
+
+    for iter in 1:max_iter
+        mul!(X2, X, X)         # X2 = X * X
+        mul!(X_new, A_bar, X2) # X_new = A_bar * X2
+        axpy!(1, C_bar, X_new) # X_new += C_bar
+        lmul!(-1, X_new)       # X_new = -X_new
+
+        copy!(diff, X_new)
+        axpy!(-1, X, diff)
+
+        if norm(diff) <= tol
+            return X_new, iter
+        end
+
+        copy!(X, X_new)
+    end
+
+    return X, max_iter
+end
+# EVOLVE-BLOCK-END

--- a/examples/julia_matrix_equation/requirements.txt
+++ b/examples/julia_matrix_equation/requirements.txt
@@ -1,0 +1,3 @@
+# Python requirements for the evaluator
+# No external packages required
+# Julia 1.9+ must be installed separately


### PR DESCRIPTION
## Summary
- keep only the solver code inside `initial_program.jl`
- move problem generation and benchmarking to a new `benchmark.jl`
- update evaluator to call `benchmark.jl`
- document expected function signature and usage in README

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_687a6de2d998832fab733abf8c1ecade